### PR TITLE
Adds UMAD genetic operator animation scene

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "lanczos",
         "Manim",
+        "Mobject",
         "Mobjects",
         "ndarray"
     ],

--- a/umad.py
+++ b/umad.py
@@ -1,0 +1,203 @@
+import random
+from manim import * # type: ignore
+from enum import Enum, auto
+
+# Indicates, during the addition phase, at which side of a gene (left or right)
+# we're inserting a new gene.
+class Side(Enum):
+    LEFT = auto()
+    RIGHT = auto()
+
+class Umad(Scene):
+    # --- CONFIGURATION ---
+    # UMAD settings
+    ADDITION_RATE: float = 0.3
+    DELETION_RATE: float = 0.3
+
+    # Genome settings
+    GENOME_LENGTH: int = 10
+    GENE_SIDE_LENGTH: float = 0.7
+    GENE_STROKE_WIDTH: float = 2
+    GENE_FILL_OPACITY: float = 0.8
+    GENOME_BUFFER: float = 0.15
+
+    # Parent/Child colors
+    PARENT_GENE_COLOR: ManimColor = BLUE_E
+    ADDED_GENE_COLOR: ManimColor = ORANGE
+    DELETED_GENE_COLOR: ManimColor = RED
+
+    PARENT_STROKE_COLOR: ManimColor = BLACK
+    CHILD_INITIAL_FILL_COLOR: ManimColor = BLACK
+    CHILD_INITIAL_STROKE_COLOR: ManimColor = BLACK
+
+    # Layout settings
+    GENOMES_VERTICAL_BUFFER: float = 0.5
+    LABEL_BUFFER: float = 0.3
+    LABEL_FONT_SIZE: int = 36
+
+    # Crossover settings
+    CROSSOVER_LINE_COLOR: ManimColor = YELLOW
+
+    # Animation settings
+    ARROW_RUN_TIME: float = 0.25
+    PARENT_GENE_HIGHLIGHT_RUN_TIME: float = 0.75
+    GENE_COPY_RUN_TIME: float = 0.5
+
+    # Titles and labels
+    TITLE: str = "UMAD mutation operator"
+    TITLE_FONT_SIZE: int = 48
+    SUBTITLE_FONT_SIZE: int = 30
+
+    def setup(self):
+        """
+        Pre-builds all mobjects for the scene.
+
+        The setup method is called by Manim before construct, so we can use it
+        to create all the visual elements we'll need for the animation.
+        """
+        (
+            self.parent_genes,
+            self.addition_phase_genes,
+            self.deletion_phase_genes,
+            self.parent_label,
+            self.addition_label,
+            self.deletion_label,
+        ) = self.build_genomes()
+
+        self.title_text = Text(self.TITLE, font_size=self.TITLE_FONT_SIZE)
+
+        # This seed gave us a nice distribution, at least when we ran it on 30 Aug 2025
+        # 1001110110
+        random.seed(5)
+
+        super().setup()
+
+    def construct(self):
+        """Defines the animation sequence for uniform crossover."""
+        # Group all genomes and labels, center them, and add them to the scene.
+        individuals = VGroup(
+            self.parent_genes, self.addition_phase_genes, self.deletion_phase_genes,
+            self.parent_label, self.addition_label, self.deletion_label
+        )
+
+        all_mobjects = VGroup(self.title_text.next_to(individuals, UP, buff=1.3), individuals).center()
+
+        self.arrow = Arrow(start=0.5*UP, end=0.5*DOWN, color=self.CROSSOVER_LINE_COLOR,
+                           max_tip_length_to_length_ratio=0.5,
+                           max_stroke_width_to_length_ratio=10)
+        self.arrow.next_to(self.parent_genes[0], UP)
+
+        self.add(all_mobjects)
+
+        self.wait(0.5)
+
+        # Animate the gene copying process.
+
+        self.animate_additions()
+        self.wait(1)
+        self.animate_deletions()
+
+        # parents = [self.parent1_genes, self.parent2_genes]
+        # for index in range(self.GENOME_LENGTH):
+        #     self.point_to_gene(self.parent1_genes[index])
+        #     which_parent = random.choice(parents)
+        #     # Highlight the parent gene chosen for copying
+        #     self.play(Circumscribe(which_parent[index]), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
+        #     # Copy the genes for a given gene from the appropriate parent to the child.
+        #     self.copy_gene(index, which_parent, self.child_genes)
+
+        # self.remove(self.arrow)
+
+        # Final wait
+        self.wait(1)
+
+    def animate_additions(self):
+        subtitle = "Addition phase"
+        subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.25)
+        self.add(subtitle_text)
+
+        self.addition_phase_genes.become(self.parent_genes, match_center=True)
+        self.play(TransformFromCopy(self.parent_genes, self.addition_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
+
+        for index in range(len(self.addition_phase_genes)):
+            self.point_to_gene(self.addition_phase_genes[index])
+            insert_here = random.random() < self.ADDITION_RATE
+            if insert_here:
+                which_side = random.choice(list(Side))
+
+
+            # # Highlight the parent gene chosen for copying
+            # self.play(Circumscribe(which_parent[index]), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
+            # # Copy the genes for a given gene from the appropriate parent to the child.
+            # self.copy_gene(index, which_parent, self.deletion_phase_genes)
+
+            self.wait(0.1)
+
+        self.remove(self.arrow)
+
+
+        self.wait(0.25)
+
+        self.remove(subtitle_text)
+        pass
+
+    def animate_deletions(self):
+        subtitle = "Deletion phase"
+        subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.5)
+        self.add(subtitle_text)
+
+        self.wait(0.25)
+
+        self.remove(subtitle_text)
+        pass
+
+    def build_genomes(self) -> tuple[VGroup, VGroup, VGroup, Text, Text, Text]:
+        """
+        Builds the parent and child genome mobjects and their labels.
+
+        This method creates the visual representations of the genomes and labels,
+        arranges them, but does not add them to the scene.
+
+        Returns:
+            A tuple containing the mobjects for parent 1 genes, parent 2 genes,
+            child genes, parent 1 label, parent 2 label, and child label.
+        """
+        parent_genes: VGroup = self.build_genome(self.PARENT_GENE_COLOR, self.PARENT_STROKE_COLOR)
+        addition_phase_genes: VGroup = self.build_genome(self.CHILD_INITIAL_FILL_COLOR, self.CHILD_INITIAL_STROKE_COLOR)
+        deletion_phase_genes: VGroup = self.build_genome(self.CHILD_INITIAL_FILL_COLOR, self.CHILD_INITIAL_STROKE_COLOR)
+
+        # Arrange genomes vertically. This modifies the mobjects in place.
+        VGroup(parent_genes, addition_phase_genes, deletion_phase_genes).arrange(DOWN, buff=self.GENOMES_VERTICAL_BUFFER)
+
+        parent_label: Text = Text("Parent genes", font_size=self.LABEL_FONT_SIZE).next_to(parent_genes, LEFT, buff=self.LABEL_BUFFER)
+        addition_label: Text = Text("Addition", font_size=self.LABEL_FONT_SIZE).next_to(addition_phase_genes, LEFT, buff=self.LABEL_BUFFER)
+        deletion_label: Text = Text("Deletion", font_size=self.LABEL_FONT_SIZE).next_to(deletion_phase_genes, LEFT, buff=self.LABEL_BUFFER)
+
+        return parent_genes, addition_phase_genes, deletion_phase_genes, parent_label, addition_label, deletion_label
+
+    def build_genome(self, fill_color: ManimColor, stroke_color: ManimColor) -> VGroup:
+        """Builds a single genome as a VGroup of squares."""
+        return VGroup(*[
+            Square(side_length=self.GENE_SIDE_LENGTH, fill_color=fill_color, fill_opacity=self.GENE_FILL_OPACITY,
+                   stroke_color=stroke_color, stroke_width=self.GENE_STROKE_WIDTH)
+            for _ in range(self.GENOME_LENGTH)
+        ]).arrange(RIGHT, buff=self.GENOME_BUFFER)
+
+
+    def point_to_gene(self, gene: Mobject):
+        self.play(self.arrow.animate.next_to(gene, UP), run_time=self.ARROW_RUN_TIME)
+
+    def copy_gene(self, index: int, from_genes: VGroup, to_genes: VGroup):
+        """
+        Animates the copying of a single gene from a parent to the child.
+
+        Args:
+            index: The position of the gene being copied.
+            from_genes: The parent genome mobject to copy from.
+            to_genes: The child genome mobject to copy to.
+        """
+        # Set the target genome square to have the same color, etc., as the parent genome.
+        # We must set `match_center` to `True`, otherwise the child's position will also
+        # be set to match the parent's, and the gene will not appear to move.
+        to_genes[index].become(from_genes[index], match_center=True)
+        self.play(TransformFromCopy(from_genes[index], to_genes[index]), run_time=self.GENE_COPY_RUN_TIME)

--- a/umad.py
+++ b/umad.py
@@ -35,7 +35,7 @@ class Umad(Scene):
     CHILD_ARROW_LENGTH: float = GENE_SIDE_LENGTH / 2
 
     # Layout settings
-    GENOMES_VERTICAL_BUFFER: float = 1
+    GENOMES_VERTICAL_BUFFER: float = 1.1
     LABEL_BUFFER: float = 0.3
     LABEL_FONT_SIZE: int = 36
 
@@ -222,7 +222,7 @@ class Umad(Scene):
         Returns:
             A tuple containing the mobjects for parent genes and the three labels.
         """
-        parent_label: Text = Text("Parent genes", font_size=self.LABEL_FONT_SIZE)
+        parent_label: Text = Text("Parent Genes", font_size=self.LABEL_FONT_SIZE)
         addition_label: Text = Text("Addition", font_size=self.LABEL_FONT_SIZE).set_opacity(0)
         deletion_label: Text = Text("Deletion", font_size=self.LABEL_FONT_SIZE).set_opacity(0)
         VGroup(parent_label, addition_label, deletion_label).arrange(DOWN, buff=self.GENOMES_VERTICAL_BUFFER)

--- a/umad.py
+++ b/umad.py
@@ -1,7 +1,7 @@
 import random
-from manim import * # type: ignore
+from manim import *
 from enum import Enum, auto
-from typing import Optional
+from typing import Optional, cast
 
 # Indicates, during the addition phase, at which side of a gene (left or right)
 # we're inserting a new gene.
@@ -68,8 +68,6 @@ class Umad(Scene):
 
         self.title_text = Text(self.TITLE, font_size=self.TITLE_FONT_SIZE)
 
-        # This seed gave us a nice distribution, at least when we ran it on 30 Aug 2025
-        # 1001110110
         random.seed(5)
 
         super().setup()

--- a/umad.py
+++ b/umad.py
@@ -105,17 +105,9 @@ class Umad(Scene):
         self.animate_additions()
         self.wait(1)
         self.animate_deletions()
+        self.wait(1)
 
-        # parents = [self.parent1_genes, self.parent2_genes]
-        # for index in range(self.GENOME_LENGTH):
-        #     self.point_to_gene(self.parent1_genes[index])
-        #     which_parent = random.choice(parents)
-        #     # Highlight the parent gene chosen for copying
-        #     self.play(Circumscribe(which_parent[index]), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
-        #     # Copy the genes for a given gene from the appropriate parent to the child.
-        #     self.copy_gene(index, which_parent, self.child_genes)
-
-        # self.remove(self.arrow)
+        self.finalize_display()
 
         # Final wait
         self.wait(1)
@@ -213,6 +205,16 @@ class Umad(Scene):
 
         self.remove(self.arrow)
         self.wait(0.25)
+
+    def finalize_display(self):
+        # Remove the addition line, moving the deletion line up into its place.
+        self.play(
+            FadeOut(self.addition_label),
+            self.deletion_label.animate.move_to(self.addition_label),
+            FadeOut(self.addition_phase_genes),
+            self.deletion_phase_genes.animate.move_to(self.addition_phase_genes)
+        )
+        pass
 
     def build_labels_and_initial_genome(self) -> tuple[VGroup, Text, Text, Text]:
         """

--- a/umad.py
+++ b/umad.py
@@ -180,7 +180,6 @@ class Umad(Scene):
         self.wait(0.25)
 
         self.remove(subtitle_text)
-        pass
 
     def animate_deletions(self):
         # TODO: Move the copying of the result of addition here.

--- a/umad.py
+++ b/umad.py
@@ -182,11 +182,7 @@ class Umad(Scene):
 
             self.wait(0.1)
 
-        self.addition_phase_genes: VGroup = VGroup()
-        for index, gene in enumerate(final_addition_phase_genes):
-            gene_copy = self.build_gene(self.PARENT_GENE_COLOR, self.PARENT_STROKE_COLOR, index, label = cast(VMobject, deepcopy(gene[1])))
-            self.addition_phase_genes.add(gene_copy)
-        self.addition_phase_genes.arrange(RIGHT, buff=self.GENOME_BUFFER).next_to(self.addition_label, RIGHT)
+        self.addition_phase_genes = final_addition_phase_genes
 
         self.remove(self.arrow)
         self.wait(0.25)
@@ -194,8 +190,13 @@ class Umad(Scene):
     def animate_deletions(self):
         self.deletion_label.set_opacity(1)
 
+        self.deletion_phase_genes: VGroup = VGroup()
+        for index, gene in enumerate(self.addition_phase_genes):
+            gene_copy = self.build_gene(self.PARENT_GENE_COLOR, self.PARENT_STROKE_COLOR, index, label = cast(VMobject, deepcopy(gene[1])))
+            self.deletion_phase_genes.add(gene_copy)
+        self.deletion_phase_genes.arrange(RIGHT, buff=self.GENOME_BUFFER).next_to(self.deletion_label, RIGHT)
+
         # Make a copy of the addition phase genes for the deletion phase
-        self.deletion_phase_genes = self.addition_phase_genes.copy().next_to(self.deletion_label, RIGHT)
         self.play(TransformFromCopy(self.addition_phase_genes, self.deletion_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
 
         for index in range(len(self.deletion_phase_genes)):

--- a/umad.py
+++ b/umad.py
@@ -1,6 +1,7 @@
 import random
 from manim import * # type: ignore
 from enum import Enum, auto
+from typing import Optional
 
 # Indicates, during the addition phase, at which side of a gene (left or right)
 # we're inserting a new gene.
@@ -15,11 +16,12 @@ class Umad(Scene):
     DELETION_RATE: float = 0.3
 
     # Genome settings
-    GENOME_LENGTH: int = 10
-    GENE_SIDE_LENGTH: float = 0.7
+    GENOME_LENGTH: int = 5
+    GENE_SIDE_LENGTH: float = 0.8
     GENE_STROKE_WIDTH: float = 2
     GENE_FILL_OPACITY: float = 0.8
     GENOME_BUFFER: float = 0.15
+    GENE_FONT_SIZE: int = 30
 
     # Parent/Child colors
     PARENT_GENE_COLOR: ManimColor = BLUE_E
@@ -122,6 +124,7 @@ class Umad(Scene):
         for index in range(len(self.addition_phase_genes)):
             self.point_to_gene(self.addition_phase_genes[index])
             insert_here = random.random() < self.ADDITION_RATE
+            ### PICK UP HERE!
             if insert_here:
                 which_side = random.choice(list(Side))
 
@@ -178,11 +181,19 @@ class Umad(Scene):
     def build_genome(self, fill_color: ManimColor, stroke_color: ManimColor) -> VGroup:
         """Builds a single genome as a VGroup of squares."""
         return VGroup(*[
-            Square(side_length=self.GENE_SIDE_LENGTH, fill_color=fill_color, fill_opacity=self.GENE_FILL_OPACITY,
-                   stroke_color=stroke_color, stroke_width=self.GENE_STROKE_WIDTH)
-            for _ in range(self.GENOME_LENGTH)
+            self.build_gene(fill_color, stroke_color, i)
+            for i in range(self.GENOME_LENGTH)
         ]).arrange(RIGHT, buff=self.GENOME_BUFFER)
 
+    def build_gene(self, fill_color: ManimColor, stroke_color: ManimColor, index: int, parent_direction: Optional[Side] = None):
+        result = VGroup() # create a VGroup
+        box = Square(
+            side_length=self.GENE_SIDE_LENGTH, fill_color=fill_color, fill_opacity=self.GENE_FILL_OPACITY,
+            stroke_color=stroke_color, stroke_width=self.GENE_STROKE_WIDTH
+        )
+        text = Text(chr(index + ord('a')), font_size=self.GENE_FONT_SIZE).move_to(box.get_center()) # create text
+        result.add(box, text) # add both objects to the VGroup
+        return result
 
     def point_to_gene(self, gene: Mobject):
         self.play(self.arrow.animate.next_to(gene, UP), run_time=self.ARROW_RUN_TIME)

--- a/umad.py
+++ b/umad.py
@@ -2,6 +2,7 @@ import random
 from manim import *
 from enum import Enum, auto
 from typing import Optional, cast
+from copy import deepcopy
 
 # Indicates, during the addition phase, at which side of a gene (left or right)
 # we're inserting a new gene.
@@ -202,6 +203,22 @@ class Umad(Scene):
         # Make a copy of the addition phase genes for the deletion phase
         self.deletion_phase_genes = self.addition_phase_genes.copy().next_to(self.deletion_label, RIGHT)
         self.play(TransformFromCopy(self.addition_phase_genes, self.deletion_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
+
+        for index in range(len(self.deletion_phase_genes)):
+            gene = cast(VMobject, self.deletion_phase_genes[index])
+            self.point_to_gene(gene)
+            self.play(Circumscribe(gene), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
+
+            delete_here = random.random() < self.DELETION_RATE
+            if delete_here:
+                deleted_gene = gene.copy()
+                deleted_gene.set_opacity(0.25)
+                self.play(Transform(gene, deleted_gene))
+                pass
+            else:
+                pass
+
+        self.remove(self.arrow)
 
         self.wait(0.25)
 

--- a/umad.py
+++ b/umad.py
@@ -25,7 +25,7 @@ class Umad(Scene):
 
     # Parent/Child colors
     PARENT_GENE_COLOR: ManimColor = BLUE_E
-    ADDED_GENE_COLOR: ManimColor = ORANGE
+    ADDED_GENE_COLOR: ManimColor = GREEN
     DELETED_GENE_COLOR: ManimColor = RED
 
     PARENT_STROKE_COLOR: ManimColor = BLACK
@@ -130,12 +130,17 @@ class Umad(Scene):
         self.play(TransformFromCopy(self.parent_genes, self.addition_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
 
         for index in range(len(self.addition_phase_genes)):
-            self.point_to_gene(self.addition_phase_genes[index])
+            gene = self.addition_phase_genes[index]
+            self.point_to_gene(gene)
             insert_here = random.random() < self.ADDITION_RATE
-            ### PICK UP HERE!
+            # We have to call `set_color` on `gene[0]` to make sure
+            # we're only changing the color of the square and not affecting
+            # the color of the text.
             if insert_here:
-                which_side = random.choice(list(Side))
-
+                # which_side = random.choice(list(Side))
+                gene[0].set_color(self.ADDED_GENE_COLOR)
+            else:
+                gene[0].set_color(self.DELETED_GENE_COLOR)
 
             # # Highlight the parent gene chosen for copying
             # self.play(Circumscribe(which_parent[index]), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)

--- a/umad.py
+++ b/umad.py
@@ -118,14 +118,15 @@ class Umad(Scene):
         self.wait(1)
 
     def animate_additions(self):
-        # TODO: Move the copying of the initial genome here
         subtitle = "Addition phase"
         subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.25)
         self.add(subtitle_text)
 
-        self.addition_phase_genes.become(self.parent_genes, match_center=True)
+        # Make a copy of the parent genes for the addition phase
+        self.addition_phase_genes = self.parent_genes.copy().next_to(self.addition_label, RIGHT)
         self.play(TransformFromCopy(self.parent_genes, self.addition_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
 
+        # The distance between two adjacent genes
         shift_distance = self.addition_phase_genes[1].get_center() - self.addition_phase_genes[0].get_center()
 
         current_parent_gene_position = 0

--- a/umad.py
+++ b/umad.py
@@ -120,6 +120,7 @@ class Umad(Scene):
         self.wait(1)
 
     def animate_additions(self):
+        # TODO: Move the copying of the initial genome here
         subtitle = "Addition phase"
         subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.25)
         self.add(subtitle_text)
@@ -220,6 +221,7 @@ class Umad(Scene):
             stroke_color=stroke_color, stroke_width=self.GENE_STROKE_WIDTH
         )
         text = Text(chr(index + ord('a')), font_size=self.GENE_FONT_SIZE).move_to(box.get_center()) # create text
+        # TODO: Add the arrow if it's present
         result.add(box, text) # add both objects to the VGroup
         return result
 

--- a/umad.py
+++ b/umad.py
@@ -127,28 +127,44 @@ class Umad(Scene):
         self.addition_phase_genes.become(self.parent_genes, match_center=True)
         self.play(TransformFromCopy(self.parent_genes, self.addition_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
 
+        shift_distance = self.addition_phase_genes[1].get_center() - self.addition_phase_genes[0].get_center()
+
+        current_parent_gene_position = 0
         for index in range(len(self.addition_phase_genes)):
-            gene = self.addition_phase_genes[index]
+            gene = self.addition_phase_genes[current_parent_gene_position]
             self.point_to_gene(gene)
+            self.play(Circumscribe(gene), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
             insert_here = random.random() < self.ADDITION_RATE
             # We have to call `set_color` on `gene[0]` to make sure
             # we're only changing the color of the square and not affecting
             # the color of the text.
             if insert_here:
+                # cast(VMobject, gene[0]).set_fill(self.ADDED_GENE_COLOR)
                 # which_side = random.choice(list(Side))
-                gene[0].set_color(self.ADDED_GENE_COLOR)
-            else:
-                gene[0].set_color(self.DELETED_GENE_COLOR)
+                which_side = Side.LEFT
+                shift_start = current_parent_gene_position
+                if which_side == Side.RIGHT:
+                    shift_start += 1
+                shifts = [MoveAlongPath(gene, Line(gene.get_center(), gene.get_center() + shift_distance))
+                          for gene in self.addition_phase_genes[shift_start:]]
+                # If the inserted gene is on the left, then we also need to shift the
+                # arrow the width of one gene to the right.
+                if which_side == Side.LEFT:
+                    shifts.append(MoveAlongPath(self.arrow, Line(self.arrow.get_center(), self.arrow.get_center() + shift_distance)))
+                self.play(
+                    AnimationGroup(shifts),
+                    rate_func=rate_functions.ease_in_out_sine)
 
-            # # Highlight the parent gene chosen for copying
-            # self.play(Circumscribe(which_parent[index]), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
-            # # Copy the genes for a given gene from the appropriate parent to the child.
-            # self.copy_gene(index, which_parent, self.deletion_phase_genes)
+                ## START HERE
+
+                # Insert the new gene and the arrow
+                # current_parent_gene_position += 1
+
+            current_parent_gene_position += 1
 
             self.wait(0.1)
 
         self.remove(self.arrow)
-
 
         self.wait(0.25)
 
@@ -156,6 +172,7 @@ class Umad(Scene):
         pass
 
     def animate_deletions(self):
+        # TODO: Move the copying of the result of addition here.
         subtitle = "Deletion phase"
         subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.5)
         self.add(subtitle_text)

--- a/umad.py
+++ b/umad.py
@@ -237,7 +237,10 @@ class Umad(Scene):
             for i in range(self.GENOME_LENGTH)
         ]).arrange(RIGHT, buff=self.GENOME_BUFFER)
 
-    def build_gene(self, fill_color: ManimColor, stroke_color: ManimColor, index: int, parent_direction: Optional[Side] = None):
+    def build_gene(self, fill_color: ManimColor, stroke_color: ManimColor,
+                   index: int,
+                   parent_direction: Optional[Side] = None,
+                   label: Optional[VMobject] = None):
         result = VGroup() # create a VGroup
         box = Square(
             side_length=self.GENE_SIDE_LENGTH, fill_color=fill_color, fill_opacity=self.GENE_FILL_OPACITY,
@@ -245,7 +248,10 @@ class Umad(Scene):
         )
         char_text = chr(index + ord('a'))
         suffix = "" if parent_direction is None else "_c"
-        text = MathTex(f"{char_text}{suffix}", font_size=self.GENE_FONT_SIZE).move_to(box.get_center()) # create text
+        if label:
+            text = label.move_to(box.get_center())
+        else:
+            text = MathTex(f"{char_text}{suffix}", font_size=self.GENE_FONT_SIZE).move_to(box.get_center()) # create text
         result.add(box, text) # add both objects to the VGroup
         if parent_direction != None:
             direction = 1 if parent_direction == Side.LEFT else -1

--- a/umad.py
+++ b/umad.py
@@ -33,6 +33,7 @@ class Umad(Scene):
     CHILD_INITIAL_FILL_COLOR: ManimColor = BLACK
     CHILD_INITIAL_STROKE_COLOR: ManimColor = BLACK
     CHILD_ARROW_LENGTH: float = GENE_SIDE_LENGTH / 2
+    ARROW_BUFF: float = 0.05
 
     # Layout settings
     GENOMES_VERTICAL_BUFFER: float = 1.1
@@ -270,4 +271,4 @@ class Umad(Scene):
         return result
 
     def point_to_gene(self, gene: Mobject):
-        self.play(self.arrow.animate.next_to(gene, UP), run_time=self.ARROW_RUN_TIME)
+        self.play(self.arrow.animate.next_to(gene, UP, buff = self.ARROW_BUFF), run_time=self.ARROW_RUN_TIME)

--- a/umad.py
+++ b/umad.py
@@ -13,8 +13,8 @@ class Side(Enum):
 class Umad(Scene):
     # --- CONFIGURATION ---
     # UMAD settings
-    ADDITION_RATE: float = 0.3
-    DELETION_RATE: float = 0.3
+    ADDITION_RATE: float = 0.6
+    DELETION_RATE: float = 0.7
 
     # Genome settings
     GENOME_LENGTH: int = 5
@@ -69,7 +69,7 @@ class Umad(Scene):
 
         self.title_text = Text(self.TITLE, font_size=self.TITLE_FONT_SIZE)
 
-        random.seed(5)
+        random.seed(9)
 
         super().setup()
 
@@ -189,7 +189,10 @@ class Umad(Scene):
         self.deletion_phase_genes.arrange(RIGHT, buff=self.GENOME_BUFFER).next_to(self.deletion_label, RIGHT)
 
         # Make a copy of the addition phase genes for the deletion phase
-        self.play(TransformFromCopy(self.addition_phase_genes, self.deletion_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
+        addition_phase_genes_copy = self.addition_phase_genes.copy()
+        self.play(Transform(addition_phase_genes_copy, self.deletion_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
+        self.add(self.deletion_phase_genes)
+        self.remove(addition_phase_genes_copy)
 
         for index in range(len(self.deletion_phase_genes)):
             gene = cast(VMobject, self.deletion_phase_genes[index])
@@ -201,7 +204,6 @@ class Umad(Scene):
                 deleted_gene = gene.copy()
                 deleted_gene.set_opacity(0.25)
                 self.play(Transform(gene, deleted_gene))
-                pass
 
         self.remove(self.arrow)
         self.wait(0.25)

--- a/umad.py
+++ b/umad.py
@@ -216,25 +216,21 @@ class Umad(Scene):
             side_length=self.GENE_SIDE_LENGTH, fill_color=fill_color, fill_opacity=self.GENE_FILL_OPACITY,
             stroke_color=stroke_color, stroke_width=self.GENE_STROKE_WIDTH
         )
-        text = Text(chr(index + ord('a')), font_size=self.GENE_FONT_SIZE).move_to(box.get_center()) # create text
-        # TODO: Add the arrow if it's present
+        char_text = chr(index + ord('a'))
+        suffix = "" if parent_direction is None else "_c"
+        text = MathTex(f"{char_text}{suffix}", font_size=self.GENE_FONT_SIZE).move_to(box.get_center()) # create text
         result.add(box, text) # add both objects to the VGroup
+        if parent_direction != None:
+            direction = 1 if parent_direction == Side.LEFT else -1
+            arrow = Arrow(
+                start=direction * 0.5 * self.CHILD_ARROW_LENGTH * LEFT,
+                  end=direction * 0.5 * self.CHILD_ARROW_LENGTH * RIGHT,
+                  color=self.CROSSOVER_LINE_COLOR,
+                  max_tip_length_to_length_ratio=0.5,
+                  max_stroke_width_to_length_ratio=10
+                ).align_to(box, UP).shift(DOWN * 0.05).align_to(box, RIGHT * direction).shift(RIGHT * 0.1 * direction)
+            result.add(arrow)
         return result
 
     def point_to_gene(self, gene: Mobject):
         self.play(self.arrow.animate.next_to(gene, UP), run_time=self.ARROW_RUN_TIME)
-
-    def copy_gene(self, index: int, from_genes: VGroup, to_genes: VGroup):
-        """
-        Animates the copying of a single gene from a parent to the child.
-
-        Args:
-            index: The position of the gene being copied.
-            from_genes: The parent genome mobject to copy from.
-            to_genes: The child genome mobject to copy to.
-        """
-        # Set the target genome square to have the same color, etc., as the parent genome.
-        # We must set `match_center` to `True`, otherwise the child's position will also
-        # be set to match the parent's, and the gene will not appear to move.
-        to_genes[index].become(from_genes[index], match_center=True)
-        self.play(TransformFromCopy(from_genes[index], to_genes[index]), run_time=self.GENE_COPY_RUN_TIME)

--- a/umad.py
+++ b/umad.py
@@ -136,30 +136,40 @@ class Umad(Scene):
             self.point_to_gene(gene)
             self.play(Circumscribe(gene), run_time=self.PARENT_GENE_HIGHLIGHT_RUN_TIME)
             insert_here = random.random() < self.ADDITION_RATE
-            # We have to call `set_color` on `gene[0]` to make sure
-            # we're only changing the color of the square and not affecting
-            # the color of the text.
             if insert_here:
-                # cast(VMobject, gene[0]).set_fill(self.ADDED_GENE_COLOR)
-                # which_side = random.choice(list(Side))
-                which_side = Side.LEFT
+                which_side = random.choice(list(Side))
+                # `shift_start` is the index of the first gene that will need to be shifted to
+                # the right to make room for the new gene.
                 shift_start = current_parent_gene_position
                 if which_side == Side.RIGHT:
                     shift_start += 1
-                shifts = [MoveAlongPath(gene, Line(gene.get_center(), gene.get_center() + shift_distance))
-                          for gene in self.addition_phase_genes[shift_start:]]
+                changes = [MoveAlongPath(gene, Line(gene.get_center(), gene.get_center() + shift_distance))
+                           for gene in self.addition_phase_genes[shift_start:]]
                 # If the inserted gene is on the left, then we also need to shift the
                 # arrow the width of one gene to the right.
                 if which_side == Side.LEFT:
-                    shifts.append(MoveAlongPath(self.arrow, Line(self.arrow.get_center(), self.arrow.get_center() + shift_distance)))
+                    changes.append(
+                        MoveAlongPath(self.arrow, Line(self.arrow.get_center(), self.arrow.get_center() + shift_distance))
+                    )
+                child_gene = self.build_gene(self.ADDED_GENE_COLOR, self.PARENT_STROKE_COLOR, current_parent_gene_position, which_side)
+                # Placing the gene is awkward because of the arrow, which changes the width of the
+                # gene's VGroup.
+                #
+                # The `move_to` calls position according to `child_gene.get_center()`, but we want
+                # to position according to `child_gene[0].get_center()` (the center of the child gene's
+                # box), so we shift by the difference between those two centers.
+                if which_side == Side.LEFT:
+                    child_gene.move_to(gene.get_center())
+                else:
+                    child_gene.move_to(
+                        gene.get_center() + RIGHT * (self.GENE_SIDE_LENGTH + self.GENOME_BUFFER)
+                    )
+                child_gene.shift(child_gene.get_center() - child_gene[0].get_center())
+
+                self.add(child_gene)
                 self.play(
-                    AnimationGroup(shifts),
+                    AnimationGroup(changes),
                     rate_func=rate_functions.ease_in_out_sine)
-
-                ## START HERE
-
-                # Insert the new gene and the arrow
-                # current_parent_gene_position += 1
 
             current_parent_gene_position += 1
 

--- a/umad.py
+++ b/umad.py
@@ -182,7 +182,12 @@ class Umad(Scene):
 
             self.wait(0.1)
 
-        self.addition_phase_genes = final_addition_phase_genes
+        self.addition_phase_genes: VGroup = VGroup()
+        for index, gene in enumerate(final_addition_phase_genes):
+            gene_copy = self.build_gene(self.PARENT_GENE_COLOR, self.PARENT_STROKE_COLOR, index, label = cast(VMobject, deepcopy(gene[1])))
+            self.addition_phase_genes.add(gene_copy)
+        self.addition_phase_genes.arrange(RIGHT, buff=self.GENOME_BUFFER).next_to(self.addition_label, RIGHT)
+
         self.remove(self.arrow)
 
         self.wait(0.25)

--- a/umad.py
+++ b/umad.py
@@ -59,12 +59,10 @@ class Umad(Scene):
         """
         (
             self.parent_genes,
-            self.addition_phase_genes,
-            self.deletion_phase_genes,
             self.parent_label,
             self.addition_label,
             self.deletion_label,
-        ) = self.build_genomes()
+        ) = self.build_labels_and_initial_genome()
 
         self.title_text = Text(self.TITLE, font_size=self.TITLE_FONT_SIZE)
 
@@ -74,18 +72,18 @@ class Umad(Scene):
 
     def construct(self):
         """Defines the animation sequence for uniform crossover."""
-        # Group all genomes and labels, center them, and add them to the scene.
-        individuals = VGroup(
-            self.parent_genes, self.addition_phase_genes, self.deletion_phase_genes,
+        # Group all the labels and the initial genome, and add them to the scene, aligned to the left.
+        labels_and_genes = VGroup(
+            self.parent_genes,
             self.parent_label, self.addition_label, self.deletion_label
         ).to_edge(LEFT)
 
-        title = self.title_text.next_to(individuals, UP, buff=1.3)
+        title = self.title_text.next_to(labels_and_genes, UP, buff=1.3)
         center = title.get_center()
         center[1] = 0
         title = title.shift(-center)
 
-        all_mobjects = VGroup(title, individuals)
+        all_mobjects = VGroup(title, labels_and_genes)
         center = all_mobjects.get_center()
         center[0] = 0
         all_mobjects = all_mobjects.shift(-center)
@@ -183,29 +181,27 @@ class Umad(Scene):
         self.remove(subtitle_text)
         pass
 
-    def build_genomes(self) -> tuple[VGroup, VGroup, VGroup, Text, Text, Text]:
+    def build_labels_and_initial_genome(self) -> tuple[VGroup, Text, Text, Text]:
         """
-        Builds the parent and child genome mobjects and their labels.
+        Builds the parent, addition, and deletion labels, and the parent child genome mobject.
 
-        This method creates the visual representations of the genomes and labels,
+        This method creates the visual representations of the initial genome and all three labels,
         arranges them, but does not add them to the scene.
 
         Returns:
-            A tuple containing the mobjects for parent 1 genes, parent 2 genes,
-            child genes, parent 1 label, parent 2 label, and child label.
+            A tuple containing the mobjects for parent genes and the three labels.
         """
-        parent_genes: VGroup = self.build_genome(self.PARENT_GENE_COLOR, self.PARENT_STROKE_COLOR)
-        addition_phase_genes: VGroup = self.build_genome(self.CHILD_INITIAL_FILL_COLOR, self.CHILD_INITIAL_STROKE_COLOR)
-        deletion_phase_genes: VGroup = self.build_genome(self.CHILD_INITIAL_FILL_COLOR, self.CHILD_INITIAL_STROKE_COLOR)
+        parent_label: Text = Text("Parent genes", font_size=self.LABEL_FONT_SIZE)
+        addition_label: Text = Text("Addition", font_size=self.LABEL_FONT_SIZE)
+        deletion_label: Text = Text("Deletion", font_size=self.LABEL_FONT_SIZE)
+        VGroup(parent_label, addition_label, deletion_label).arrange(DOWN, buff=self.GENOMES_VERTICAL_BUFFER)
+        # Right aligns all the labels
+        addition_label.align_to(parent_label, RIGHT)
+        deletion_label.align_to(parent_label, RIGHT)
 
-        # Arrange genomes vertically. This modifies the mobjects in place.
-        VGroup(parent_genes, addition_phase_genes, deletion_phase_genes).arrange(DOWN, buff=self.GENOMES_VERTICAL_BUFFER)
+        parent_genes: VGroup = self.build_genome(self.PARENT_GENE_COLOR, self.PARENT_STROKE_COLOR).next_to(parent_label, RIGHT, buff=self.LABEL_BUFFER)
 
-        parent_label: Text = Text("Parent genes", font_size=self.LABEL_FONT_SIZE).next_to(parent_genes, LEFT, buff=self.LABEL_BUFFER)
-        addition_label: Text = Text("Addition", font_size=self.LABEL_FONT_SIZE).next_to(addition_phase_genes, LEFT, buff=self.LABEL_BUFFER)
-        deletion_label: Text = Text("Deletion", font_size=self.LABEL_FONT_SIZE).next_to(deletion_phase_genes, LEFT, buff=self.LABEL_BUFFER)
-
-        return parent_genes, addition_phase_genes, deletion_phase_genes, parent_label, addition_label, deletion_label
+        return parent_genes, parent_label, addition_label, deletion_label
 
     def build_genome(self, fill_color: ManimColor, stroke_color: ManimColor) -> VGroup:
         """Builds a single genome as a VGroup of squares."""

--- a/umad.py
+++ b/umad.py
@@ -130,6 +130,9 @@ class Umad(Scene):
         # The distance between two adjacent genes
         shift_distance = self.addition_phase_genes[1].get_center() - self.addition_phase_genes[0].get_center()
 
+        # A VGroup that will contain all the parent genes and all the newly inserted child genes.
+        final_addition_phase_genes: VGroup = VGroup()
+
         current_parent_gene_position = 0
         for index in range(len(self.addition_phase_genes)):
             gene = self.addition_phase_genes[current_parent_gene_position]
@@ -160,21 +163,26 @@ class Umad(Scene):
                 # box), so we shift by the difference between those two centers.
                 if which_side == Side.LEFT:
                     child_gene.move_to(gene.get_center())
+                    final_addition_phase_genes.add(*[child_gene, gene])
                 else:
                     child_gene.move_to(
                         gene.get_center() + RIGHT * (self.GENE_SIDE_LENGTH + self.GENOME_BUFFER)
                     )
+                    final_addition_phase_genes.add(*[gene, child_gene])
                 child_gene.shift(child_gene.get_center() - child_gene[0].get_center())
 
                 self.add(child_gene)
                 self.play(
                     AnimationGroup(changes),
                     rate_func=rate_functions.ease_in_out_sine)
+            else:
+                final_addition_phase_genes.add(cast(VMobject, gene))
 
             current_parent_gene_position += 1
 
             self.wait(0.1)
 
+        self.addition_phase_genes = final_addition_phase_genes
         self.remove(self.arrow)
 
         self.wait(0.25)

--- a/umad.py
+++ b/umad.py
@@ -33,7 +33,7 @@ class Umad(Scene):
     CHILD_INITIAL_STROKE_COLOR: ManimColor = BLACK
 
     # Layout settings
-    GENOMES_VERTICAL_BUFFER: float = 0.5
+    GENOMES_VERTICAL_BUFFER: float = 1
     LABEL_BUFFER: float = 0.3
     LABEL_FONT_SIZE: int = 36
 
@@ -80,9 +80,17 @@ class Umad(Scene):
         individuals = VGroup(
             self.parent_genes, self.addition_phase_genes, self.deletion_phase_genes,
             self.parent_label, self.addition_label, self.deletion_label
-        )
+        ).to_edge(LEFT)
 
-        all_mobjects = VGroup(self.title_text.next_to(individuals, UP, buff=1.3), individuals).center()
+        title = self.title_text.next_to(individuals, UP, buff=1.3)
+        center = title.get_center()
+        center[1] = 0
+        title = title.shift(-center)
+
+        all_mobjects = VGroup(title, individuals)
+        center = all_mobjects.get_center()
+        center[0] = 0
+        all_mobjects = all_mobjects.shift(-center)
 
         self.arrow = Arrow(start=0.5*UP, end=0.5*DOWN, color=self.CROSSOVER_LINE_COLOR,
                            max_tip_length_to_length_ratio=0.5,

--- a/umad.py
+++ b/umad.py
@@ -257,7 +257,7 @@ class Umad(Scene):
             stroke_color=stroke_color, stroke_width=self.GENE_STROKE_WIDTH
         )
         char_text = chr(index + ord('a'))
-        suffix = "" if parent_direction is None else "_c"
+        suffix = "" if parent_direction is None else "_a"
         if label:
             text = label.move_to(box.get_center())
         else:

--- a/umad.py
+++ b/umad.py
@@ -31,6 +31,7 @@ class Umad(Scene):
     PARENT_STROKE_COLOR: ManimColor = BLACK
     CHILD_INITIAL_FILL_COLOR: ManimColor = BLACK
     CHILD_INITIAL_STROKE_COLOR: ManimColor = BLACK
+    CHILD_ARROW_LENGTH: float = GENE_SIDE_LENGTH / 2
 
     # Layout settings
     GENOMES_VERTICAL_BUFFER: float = 1

--- a/umad.py
+++ b/umad.py
@@ -190,10 +190,13 @@ class Umad(Scene):
         self.remove(subtitle_text)
 
     def animate_deletions(self):
-        # TODO: Move the copying of the result of addition here.
         subtitle = "Deletion phase"
         subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.5)
         self.add(subtitle_text)
+
+        # Make a copy of the addition phase genes for the deletion phase
+        self.deletion_phase_genes = self.addition_phase_genes.copy().next_to(self.deletion_label, RIGHT)
+        self.play(TransformFromCopy(self.addition_phase_genes, self.deletion_phase_genes), run_time=self.GENE_COPY_RUN_TIME)
 
         self.wait(0.25)
 

--- a/umad.py
+++ b/umad.py
@@ -50,7 +50,7 @@ class Umad(Scene):
     # Titles and labels
     TITLE: str = "UMAD mutation operator"
     TITLE_FONT_SIZE: int = 48
-    SUBTITLE_FONT_SIZE: int = 30
+    TITLE_OFFSET = 0.7
 
     def setup(self):
         """
@@ -80,7 +80,7 @@ class Umad(Scene):
             self.parent_label, self.addition_label, self.deletion_label
         ).to_edge(LEFT)
 
-        title = self.title_text.next_to(labels_and_genes, UP, buff=1.3)
+        title = self.title_text.next_to(labels_and_genes, UP, buff=self.TITLE_OFFSET)
         center = title.get_center()
         center[1] = 0
         title = title.shift(-center)
@@ -120,9 +120,7 @@ class Umad(Scene):
         self.wait(1)
 
     def animate_additions(self):
-        subtitle = "Addition phase"
-        subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.25)
-        self.add(subtitle_text)
+        self.addition_label.set_opacity(1)
 
         # Make a copy of the parent genes for the addition phase
         self.addition_phase_genes = self.parent_genes.copy().next_to(self.addition_label, RIGHT)
@@ -190,15 +188,10 @@ class Umad(Scene):
         self.addition_phase_genes.arrange(RIGHT, buff=self.GENOME_BUFFER).next_to(self.addition_label, RIGHT)
 
         self.remove(self.arrow)
-
         self.wait(0.25)
 
-        self.remove(subtitle_text)
-
     def animate_deletions(self):
-        subtitle = "Deletion phase"
-        subtitle_text = Text(subtitle, font_size=self.SUBTITLE_FONT_SIZE, slant=ITALIC).next_to(self.title_text, DOWN, buff=0.5)
-        self.add(subtitle_text)
+        self.deletion_label.set_opacity(1)
 
         # Make a copy of the addition phase genes for the deletion phase
         self.deletion_phase_genes = self.addition_phase_genes.copy().next_to(self.deletion_label, RIGHT)
@@ -215,15 +208,9 @@ class Umad(Scene):
                 deleted_gene.set_opacity(0.25)
                 self.play(Transform(gene, deleted_gene))
                 pass
-            else:
-                pass
 
         self.remove(self.arrow)
-
         self.wait(0.25)
-
-        self.remove(subtitle_text)
-        pass
 
     def build_labels_and_initial_genome(self) -> tuple[VGroup, Text, Text, Text]:
         """
@@ -236,8 +223,8 @@ class Umad(Scene):
             A tuple containing the mobjects for parent genes and the three labels.
         """
         parent_label: Text = Text("Parent genes", font_size=self.LABEL_FONT_SIZE)
-        addition_label: Text = Text("Addition", font_size=self.LABEL_FONT_SIZE)
-        deletion_label: Text = Text("Deletion", font_size=self.LABEL_FONT_SIZE)
+        addition_label: Text = Text("Addition", font_size=self.LABEL_FONT_SIZE).set_opacity(0)
+        deletion_label: Text = Text("Deletion", font_size=self.LABEL_FONT_SIZE).set_opacity(0)
         VGroup(parent_label, addition_label, deletion_label).arrange(DOWN, buff=self.GENOMES_VERTICAL_BUFFER)
         # Right aligns all the labels
         addition_label.align_to(parent_label, RIGHT)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -44,16 +44,38 @@ wheels = [
 
 [[package]]
 name = "av"
-version = "13.1.0"
+version = "16.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/9d/486d31e76784cc0ad943f420c5e05867263b32b37e2f4b0f7f22fdc1ca3a/av-13.1.0.tar.gz", hash = "sha256:d3da736c55847d8596eb8c26c60e036f193001db3bc5c10da8665622d906c17e", size = 3957908, upload-time = "2024-10-06T04:54:57.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203, upload-time = "2026-01-11T07:31:33.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/6e/cdce12e534570df37d3fdcb3a74851d39e9ab79d388f3174dea9785a011a/av-13.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47642ebaebfe20519b2391bd5b7c38b596efcd052bfd09c8d33058f94ddd0fd6", size = 24229340, upload-time = "2024-10-06T04:53:33.25Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/88/5359aeada9ea509426f2db63b6531833824a1b02470667b103479ddea7ae/av-13.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2f079c2daa3ae06557b3f6e9bed4fb9c876e8012175bec645ccd007199a302db", size = 19436445, upload-time = "2024-10-06T04:53:36.573Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/d4/64995e5b800476c86dae4ea1444a0eac44e2c4985fac6401b08401e2df11/av-13.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f0de8252deeeb1887637e88d4d9d18514e5cfe276bdb9e6ca8e9eef89d1667a", size = 32120549, upload-time = "2024-10-06T04:53:39.752Z" },
-    { url = "https://files.pythonhosted.org/packages/68/76/9910694cf87d2d308d851f5b2b5c5b20f7f55411f596e2c158fb13bf84a3/av-13.1.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9ad0024f4def11b0cedfeee478fa6c6fd7ed3955e13387e0f27261fdda6121b4", size = 31495305, upload-time = "2024-10-06T04:53:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a8/cd92de947b9595a0eb2c64e6f7ba295aac2687972050ae092173c2f6ea0c/av-13.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb88e2590eaed45233eb117f1dfab1a43ed9a997b2c46da9f08468dd00f14895", size = 34065325, upload-time = "2024-10-06T04:53:47.25Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/d0/9869fcbd66422df2033d4b78a663e3c64aa6fe7eb9189c811d60f69d9871/av-13.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:c927e4fa4f6aeed4340b3e3b16b237d7cb743e5c1a55b92307407590ca4112aa", size = 25754728, upload-time = "2024-10-06T04:53:50.603Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2a/63797a4dde34283dd8054219fcb29294ba1c25d68ba8c8c8a6ae53c62c45/av-16.1.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:ce2a1b3d8bf619f6c47a9f28cfa7518ff75ddd516c234a4ee351037b05e6a587", size = 26916715, upload-time = "2026-01-11T09:57:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c4/0b49cf730d0ae8cda925402f18ae814aef351f5772d14da72dd87ff66448/av-16.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:408dbe6a2573ca58a855eb8cd854112b33ea598651902c36709f5f84c991ed8e", size = 21452167, upload-time = "2026-01-11T09:57:50.606Z" },
+    { url = "https://files.pythonhosted.org/packages/51/23/408806503e8d5d840975aad5699b153aaa21eb6de41ade75248a79b7a37f/av-16.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57f657f86652a160a8a01887aaab82282f9e629abf94c780bbdbb01595d6f0f7", size = 39215659, upload-time = "2026-01-11T09:57:53.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/19/a8528d5bba592b3903f44c28dab9cc653c95fcf7393f382d2751a1d1523e/av-16.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:adbad2b355c2ee4552cac59762809d791bda90586d134a33c6f13727fb86cb3a", size = 40874970, upload-time = "2026-01-11T09:57:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/24/2dbcdf0e929ad56b7df078e514e7bd4ca0d45cba798aff3c8caac097d2f7/av-16.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f42e1a68ec2aebd21f7eb6895be69efa6aa27eec1670536876399725bbda4b99", size = 40530345, upload-time = "2026-01-11T09:58:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/54/27/ae91b41207f34e99602d1c72ab6ffd9c51d7c67e3fbcd4e3a6c0e54f882c/av-16.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58fe47aeaef0f100c40ec8a5de9abbd37f118d3ca03829a1009cf288e9aef67c", size = 41972163, upload-time = "2026-01-11T09:58:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/22158fb923b2a9a00dfab0e96ef2e8a1763a94dd89e666a5858412383d46/av-16.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:565093ebc93b2f4b76782589564869dadfa83af5b852edebedd8fee746457d06", size = 31729230, upload-time = "2026-01-11T09:58:07.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f1/878f8687d801d6c4565d57ebec08449c46f75126ebca8e0fed6986599627/av-16.1.0-cp313-cp313t-macosx_11_0_x86_64.whl", hash = "sha256:574081a24edb98343fd9f473e21ae155bf61443d4ec9d7708987fa597d6b04b2", size = 27008769, upload-time = "2026-01-11T09:58:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f1/bd4ce8c8b5cbf1d43e27048e436cbc9de628d48ede088a1d0a993768eb86/av-16.1.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:9ab00ea29c25ebf2ea1d1e928d7babb3532d562481c5d96c0829212b70756ad0", size = 21590588, upload-time = "2026-01-11T09:58:12.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/c81f6f9209201ff0b5d5bed6da6c6e641eef52d8fbc930d738c3f4f6f75d/av-16.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a84a91188c1071f238a9523fd42dbe567fb2e2607b22b779851b2ce0eac1b560", size = 40638029, upload-time = "2026-01-11T09:58:15.399Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4d/07edff82b78d0459a6e807e01cd280d3180ce832efc1543de80d77676722/av-16.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c2cd0de4dd022a7225ff224fde8e7971496d700be41c50adaaa26c07bb50bf97", size = 41970776, upload-time = "2026-01-11T09:58:19.075Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9d/1f48b354b82fa135d388477cd1b11b81bdd4384bd6a42a60808e2ec2d66b/av-16.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0816143530624a5a93bc5494f8c6eeaf77549b9366709c2ac8566c1e9bff6df5", size = 41764751, upload-time = "2026-01-11T09:58:22.788Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/a509801e98db35ec552dd79da7bdbcff7104044bfeb4c7d196c1ce121593/av-16.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e3a28053af29644696d0c007e897d19b1197585834660a54773e12a40b16974c", size = 43034355, upload-time = "2026-01-11T09:58:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/e5f530d9e8f640da5f5c5f681a424c65f9dd171c871cd255d8a861785a6e/av-16.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e3e67144a202b95ed299d165232533989390a9ea3119d37eccec697dc6dbb0c", size = 31947047, upload-time = "2026-01-11T09:58:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/df/18/8812221108c27d19f7e5f486a82c827923061edf55f906824ee0fcaadf50/av-16.1.0-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:39a634d8e5a87e78ea80772774bfd20c0721f0d633837ff185f36c9d14ffede4", size = 26916179, upload-time = "2026-01-11T09:58:36.506Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ef/49d128a9ddce42a2766fe2b6595bd9c49e067ad8937a560f7838a541464e/av-16.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0ba32fb9e9300948a7fa9f8a3fc686e6f7f77599a665c71eb2118fdfd2c743f9", size = 21460168, upload-time = "2026-01-11T09:58:39.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a9/b310d390844656fa74eeb8c2750e98030877c75b97551a23a77d3f982741/av-16.1.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca04d17815182d34ce3edc53cbda78a4f36e956c0fd73e3bab249872a831c4d7", size = 39210194, upload-time = "2026-01-11T09:58:42.138Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7b/e65aae179929d0f173af6e474ad1489b5b5ad4c968a62c42758d619e54cf/av-16.1.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ee0e8de2e124a9ef53c955fe2add6ee7c56cc8fd83318265549e44057db77142", size = 40811675, upload-time = "2026-01-11T09:58:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/5d7edefd26b6a5187d6fac0f5065ee286109934f3dea607ef05e53f05b31/av-16.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:22bf77a2f658827043a1e184b479c3bf25c4c43ab32353677df2d119f080e28f", size = 40543942, upload-time = "2026-01-11T09:58:49.759Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/f8b17897b67be0900a211142f5646a99d896168f54d57c81f3e018853796/av-16.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2dd419d262e6a71cab206d80bbf28e0a10d0f227b671cdf5e854c028faa2d043", size = 41924336, upload-time = "2026-01-11T09:58:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/d32bc6bbbcf60b65f6510c54690ed3ae1c4ca5d9fafbce835b6056858686/av-16.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:53585986fd431cd436f290fba662cfb44d9494fbc2949a183de00acc5b33fa88", size = 31735077, upload-time = "2026-01-11T09:58:56.684Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/9b63dc70af8636399bd933e9df4f3025a0294609510239782c1b746fc796/av-16.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:76f5ed8495cf41e1209a5775d3699dc63fdc1740b94a095e2485f13586593205", size = 27014423, upload-time = "2026-01-11T09:58:59.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/da/787a07a0d6ed35a0888d7e5cfb8c2ffa202f38b7ad2c657299fac08eb046/av-16.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:8d55397190f12a1a3ae7538be58c356cceb2bf50df1b33523817587748ce89e5", size = 21595536, upload-time = "2026-01-11T09:59:02.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f4/9a7d8651a611be6e7e3ab7b30bb43779899c8cac5f7293b9fb634c44a3f3/av-16.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9d51d9037437218261b4bbf9df78a95e216f83d7774fbfe8d289230b5b2e28e2", size = 40642490, upload-time = "2026-01-11T09:59:05.842Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e4/eb79bc538a94b4ff93cd4237d00939cba797579f3272490dd0144c165a21/av-16.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0ce07a89c15644407f49d942111ca046e323bbab0a9078ff43ee57c9b4a50dad", size = 41976905, upload-time = "2026-01-11T09:59:09.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/f6db0dd86b70167a4d55ee0d9d9640983c570d25504f2bde42599f38241e/av-16.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cac0c074892ea97113b53556ff41c99562db7b9f09f098adac1f08318c2acad5", size = 41770481, upload-time = "2026-01-11T09:59:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/33651d658e45e16ab7671ea5fcf3d20980ea7983234f4d8d0c63c65581a5/av-16.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7dec3dcbc35a187ce450f65a2e0dda820d5a9e6553eea8344a1459af11c98649", size = 43036824, upload-time = "2026-01-11T09:59:16.507Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/7f13361db54d7e02f11552575c0384dadaf0918138f4eaa82ea03a9f9580/av-16.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6f90dc082ff2068ddbe77618400b44d698d25d9c4edac57459e250c16b33d700", size = 31948164, upload-time = "2026-01-11T09:59:19.501Z" },
 ]
 
 [[package]]
@@ -163,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "manim"
-version = "0.19.0"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "audioop-lts" },
@@ -193,21 +215,25 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/79/29f287beebcf52464c2cfd88015720992515062dd373bd37c2ed34955cdd/manim-0.19.0.tar.gz", hash = "sha256:748115ffc1dea24940fd6d7a3edcae0ccedc3e1874ebc1f5d7e5c6d69a4f4505", size = 531082, upload-time = "2025-01-20T13:56:06.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/be/39066e0f1ad3c12532ee4f1dcfd02088b0aa0de9d38ba266a198ab1c09e9/manim-0.19.2.tar.gz", hash = "sha256:7cf74d7c012f19e278fcff58651e5b486a23391aa115582a24c6a0e318cd243e", size = 543858, upload-time = "2026-01-17T10:52:39.709Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/30/2993e7468ff045e19a4fbfd5c540c921b6f884faebdecc9d97534882e48b/manim-0.19.0-py3-none-any.whl", hash = "sha256:aee98d359d85733ea91f459d0ad8168da03593ce2001355432b5e31ca8bcdcaf", size = 625936, upload-time = "2025-01-20T13:56:01.928Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b2/e737825fde8f091ccd8d6e906797364273e4ad209361fe63340a378acab7/manim-0.19.2-py3-none-any.whl", hash = "sha256:b17a93c1d54812268c796f7e68577d167e4b1be20deb3e62ea6a3560881ff6f6", size = 642547, upload-time = "2026-01-17T10:52:34.951Z" },
 ]
 
 [[package]]
 name = "manimpango"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/8e/7f7a49d4bbe2c6dbef4a82c58e15fc5a35eedcf97a8f7c67ce5fa9a8c827/manimpango-0.6.0.tar.gz", hash = "sha256:d959708e5c05e87317b37df5f6c5258aa9d1ed694a0b25b19d6a4f861841e191", size = 4080822, upload-time = "2024-09-14T14:06:18.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/55/d360e73eb4d04b102cef399ddebcba486a9b6c1977a26fe710beffd52e95/manimpango-0.6.1.tar.gz", hash = "sha256:59a00bbf8e99dab5f94341087c88e609fe946e79724627429cf59da84cbd40bf", size = 4080834, upload-time = "2025-10-23T06:04:48.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/a5/14daa990d391981582ebfaabac93aeb9abbd83b3fac98800e5fe06ace653/ManimPango-0.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5156dc1fa2a6321f64a4110aa9dbe0c5ba507839f947fa3dfc72b5c63d729c88", size = 7470477, upload-time = "2024-09-14T14:06:04.723Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/63/fccfcd6b6748c3e50e0319cc976d27762543ac3f634c20d712b463677f41/ManimPango-0.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:67809f65ec10397361a2650069ccac9fcf64babf75daf58eb38d9bcfb49e968b", size = 6801196, upload-time = "2024-09-14T14:06:06.589Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/65/ea52fa1db9cf59f48b4726a1e6655ce2a2271f35ea4f11f0f2d497914624/ManimPango-0.6.0-cp313-cp313-win32.whl", hash = "sha256:ba6279fd087ac3ac0a64c24a8b47fa0bdf0c8351c177cd07e3e793252899bd2d", size = 3530715, upload-time = "2024-09-14T14:06:08.51Z" },
-    { url = "https://files.pythonhosted.org/packages/46/a7/cc2a049245b1bfd99989319e660732b18c1190c1c429c6b5dd04e79ea415/ManimPango-0.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:bb13f56a41ba251f70fd57643dc42cee689a1ebbec5eaf305722c7100008e253", size = 4097763, upload-time = "2024-09-14T14:06:09.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ee/01cd6b3087a5ead9483add3023f46c135bddd7773d506b771b44bbe0830b/manimpango-0.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:79aafe6373cb31dcdd1ee505407ec2bea18e74aed877f93dcd27ec9d88584472", size = 7751685, upload-time = "2025-10-23T06:04:28.457Z" },
+    { url = "https://files.pythonhosted.org/packages/70/93/905ac20a9190655870131940dadb5121645cf8a23e6ea0f04be7f4604f2e/manimpango-0.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1049bda27ca504d24b48bec21756f4d8a3310ea7bc690167c54d05e97b8f7639", size = 7062629, upload-time = "2025-10-23T06:04:30.059Z" },
+    { url = "https://files.pythonhosted.org/packages/76/88/b2de7d2d3a0331cf79992f8c6da0f0abd873d4ec9f024cad5992f1cf7a6d/manimpango-0.6.1-cp313-cp313-win32.whl", hash = "sha256:8da8238147b96737b36725b0fc386dc1dd7901516dfd7e73b2e7d34cd5d934f1", size = 3626705, upload-time = "2025-10-23T06:04:31.527Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ed/a7a57491b26e8fb85ac0be9c39b53a6690f3c39beaf06d3715cb6916932b/manimpango-0.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:e90d6b926d0e673ce624963d44cc28c55a368b6074108ab885a43305baeae26c", size = 4203874, upload-time = "2025-10-23T06:04:32.981Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c0/318410215b409465a237c126a3e1f612c432d33b037b2f997870df327434/manimpango-0.6.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:318d14087901ee27ed6d0cfef0335aed57db217f8de831c8ca4e4c52b7805b45", size = 7751895, upload-time = "2025-10-23T06:04:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/83/f0a05e3e6312ca9673bc8b470c6a743cf2d0bd7f08b218efc993226e72e4/manimpango-0.6.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ffe2f8353857f0ca9a16894430d871051da450bc2d19beb969cf8b57b032f580", size = 7063387, upload-time = "2025-10-23T06:04:36.877Z" },
+    { url = "https://files.pythonhosted.org/packages/13/76/0748323341647e8c338bd7af6fb527ffdc43d676003b57743740bdfcffcc/manimpango-0.6.1-cp314-cp314-win32.whl", hash = "sha256:c294ab801c8ffc217342dfeff7aeca97cbea86cd8b4e6e8c9a8d7da020b820e1", size = 3737933, upload-time = "2025-10-23T06:04:38.775Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/42b995549cfd137780045e44b3bfba2cb1247b18bd2fb9f97079048e78ac/manimpango-0.6.1-cp314-cp314-win_amd64.whl", hash = "sha256:d8b0ee675eb30bbb67097cecb2be469847c3ccf574291f2bd43360caeb5f62ed", size = 4357908, upload-time = "2025-10-23T06:04:40.641Z" },
 ]
 
 [[package]]
@@ -361,6 +387,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/59/a7/c3e5ed55781dfe1b31eb4a2482aeae707671f3d36b0ea53a1722f4a3dfe9/pycairo-1.28.0-cp313-cp313-win32.whl", hash = "sha256:d13352429d8a08a1cb3607767d23d2fb32e4c4f9faa642155383980ec1478c24", size = 750594, upload-time = "2025-04-14T20:10:59.284Z" },
     { url = "https://files.pythonhosted.org/packages/8b/1c/ebadd290748aff3b6bc35431114d41e7a42f40a4b988c2aaf2dfed5d8156/pycairo-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:082aef6b3a9dcc328fa648d38ed6b0a31c863e903ead57dd184b2e5f86790140", size = 841774, upload-time = "2025-04-14T20:11:01.79Z" },
     { url = "https://files.pythonhosted.org/packages/3e/ce/a3f5f1946613cd8a4654322b878c59f273c6e9b01dfadadd3f609070e0b9/pycairo-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:026afd53b75291917a7412d9fe46dcfbaa0c028febd46ff1132d44a53ac2c8b6", size = 691675, upload-time = "2025-04-16T19:30:26.565Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1b/1f5da2b2e44b33a5b269ff28af710b0a7903001d9cf8a40d00fc944a5092/pycairo-1.28.0-cp314-cp314-win32.whl", hash = "sha256:d0ab30585f536101ad6f09052fc3895e2a437ba57531ea07223d0e076248025d", size = 766699, upload-time = "2025-07-24T06:36:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/91/1d5f18bd3ed469b1de8f83bfbf8bd67d23439f075151b66740fd35356190/pycairo-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:94f2ed204999ab95a0671a0fa948ffbb9f3d6fb8731fe787917f6d022d9c1c0f", size = 868725, upload-time = "2025-07-24T06:36:09.597Z" },
 ]
 
 [[package]]
@@ -491,17 +519,17 @@ wheels = [
 
 [[package]]
 name = "skia-pathops"
-version = "0.8.0.post2"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/85/4c6ce1f1f3e8d3888165f2830adcf340922416c155647b12ebac2dcc423e/skia_pathops-0.8.0.post2.zip", hash = "sha256:9e252cdeb6c4d162e82986d31dbd89c675d1677cb8019c2e13e6295d4a557269", size = 66956087, upload-time = "2024-10-18T15:59:01.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/e5/2df8c918ffcb4ad847d2571f32a92447ffebe2e9c94d4ea05d9a86f20beb/skia_pathops-0.9.1.tar.gz", hash = "sha256:f1273ef4da23570f33e76e7753908484e5a4a2468f7b1089f9110ccee6293f99", size = 65116011, upload-time = "2025-12-08T11:44:49.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/bd/3036a1229952b8d96e1a5c32626d9aa0fa4cdfc9d2868829c2ab93828f75/skia_pathops-0.8.0.post2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4059d5c54dc4d2686e3b54c347fa1aad48ef6a0bc12ca75a27a260b291a98238", size = 3001951, upload-time = "2024-10-18T15:58:09.1Z" },
-    { url = "https://files.pythonhosted.org/packages/db/30/51a5e15e05d56278393666ab6ca5e43a7fc6822f2372d565f71e247af0bb/skia_pathops-0.8.0.post2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0db10dfb00a1093a72e56827c172e3ca4922762f4c321d6ccc0703bc201b966", size = 1626535, upload-time = "2024-10-18T15:58:10.962Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f3/78f942c0fdabb6da1c16b1a415c98efd256caa2191838045c9e7317218cb/skia_pathops-0.8.0.post2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ddb5b52fae729ea456e777e715d17f25940e53bbd0ca0fad8b1e6268c7f493be", size = 3177784, upload-time = "2024-10-18T15:58:13.045Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/ff/0095a0313416c68df090c29f250c900f4dba4d68b4750bcd463f9ca1c52a/skia_pathops-0.8.0.post2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7db6b12d5cd85d0dec27f8f4ff41f8e2befa76a40170cda9715f98d2002d0da1", size = 3375866, upload-time = "2024-10-18T15:58:16.235Z" },
-    { url = "https://files.pythonhosted.org/packages/12/56/a5ef7bb7fac2bbddb0937187cf1283deaee33002056bed8304d499534ea6/skia_pathops-0.8.0.post2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ae0a7937f6160247515a272f36598e35abb700ae4f1b5adec2e8119fcd535dcb", size = 4463385, upload-time = "2024-10-18T15:58:18.578Z" },
-    { url = "https://files.pythonhosted.org/packages/25/21/ab107c2cf99f047c77a01ef9b564f393a6ada8585d3337b1dcdd8488abee/skia_pathops-0.8.0.post2-cp313-cp313-win32.whl", hash = "sha256:20e759441ce209e0fe026900057ac846e6912e7112b81229c330a6ad1e550efb", size = 2330817, upload-time = "2024-10-18T15:58:22.109Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ca/cf1b0938a249d02f0b9245a3105faa1a01dd909e7cafee50c2d50899051b/skia_pathops-0.8.0.post2-cp313-cp313-win_amd64.whl", hash = "sha256:1753fd7b4151c9ae3e5f198227ab39598a60be90c7ccc5c796a6ca5ef26d24d6", size = 2916031, upload-time = "2024-10-18T15:58:24.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/39/4edc7484e2dff1ac43ea62d1df8c8b00e9ed820ca4e5efcd8371e87f4fe7/skia_pathops-0.9.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:54ac44ade7b37d3d67b04c3eea244b5f9b4e7555ccad4b6997a56602cb6f0f48", size = 2897494, upload-time = "2025-12-08T11:44:30.086Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7c/0238144453b9b99369e04ecc6393e4236ea6eac2105145cb3dcd02d80645/skia_pathops-0.9.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3a5eee648d4acff631b8eaca13984a288886bbf754999b940da85ea3bcb4b9a9", size = 3300295, upload-time = "2025-12-08T11:44:31.844Z" },
+    { url = "https://files.pythonhosted.org/packages/87/7f/268de1790fdefb3700d75ec6bb7a73e4cd67af67ce1ab290db04bd06a98b/skia_pathops-0.9.1-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dab0e9b16c98bf92be384fba2a0578a54a969fd386d995d739c8a541585dc34a", size = 2999241, upload-time = "2025-12-08T11:44:34.149Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/53/22ae66ac02476174272539e724565088045462b3591d01d8da66ce009c38/skia_pathops-0.9.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b08bb15347dfdcc91bd62aa5d63c036cdefa2152761b5c0e8288db199b7c4f72", size = 3955299, upload-time = "2025-12-08T11:44:35.501Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/799308cb5f139d4150a200122cb44475f97e81b43a3281372d59216dd9bb/skia_pathops-0.9.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:19202fd9799d5d5428a7d6f3eae0366304cd2cf4e5680541fabb016c54b44109", size = 4316602, upload-time = "2025-12-08T11:44:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/85/3b/45ff339b49dd8eed91ade81842464c6ce955f84dd6805cbe1bafc2b1cd4b/skia_pathops-0.9.1-cp310-abi3-win32.whl", hash = "sha256:56c4b3bc9c281b12693f0f2771367c53a7a20104beac203fb5cb90cb2b9a4649", size = 1450920, upload-time = "2025-12-08T11:44:38.624Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d1/698e85d5f7e2ce3b731232dc9f26e2cecb8afc66194aa494dc78c04194cc/skia_pathops-0.9.1-cp310-abi3-win_amd64.whl", hash = "sha256:e718f2e1284f05ccccde111b1280a79e33093c4af30c118a0b2f5b0753f0727e", size = 1782888, upload-time = "2025-12-08T11:44:39.983Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [ ] Fix the label on the final "Deletion" row to be something like "Child"

Introduces a new Manim scene, `Umad`, to visually demonstrate the Uniform Mutation and Deletion (UMAD) genetic operator.

This animation sequence clearly illustrates:
*   **Gene Addition**: New genes are randomly inserted, and existing genes dynamically shift to make room. Parent genes are highlighted during the consideration process.
*   **Gene Deletion**: Genes are randomly selected for removal, with a visual transformation indicating their deletion. Genes are highlighted during the consideration process.
*   The scene includes animated labels, an arrow to point to the current gene, and customizable settings for visual elements and animation timing.

Also updates several Python dependencies, including `manim`, `av`, `manimpango`, and `skia-pathops`, to their latest versions.

Closes #9